### PR TITLE
Improve energy efficiency by applying Cache Energy Pattern

### DIFF
--- a/app/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
+++ b/app/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
@@ -80,13 +80,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.GZIPInputStream;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.*;
 
 /**
  * A fluid interface for making HTTP requests using an underlying
@@ -266,7 +260,7 @@ public class HttpRequest {
     else
       return CHARSET_UTF8;
   }
-
+  
   private static SSLSocketFactory getTrustedFactory()
       throws HttpRequestException {
     if (TRUSTED_FACTORY == null) {
@@ -287,6 +281,11 @@ public class HttpRequest {
       try {
         SSLContext context = SSLContext.getInstance("TLS");
         context.init(null, trustAllCerts, new SecureRandom());
+        SSLSessionContext sslSessionContext = context.getServerSessionContext();
+        int sessionCacheSize = sslSessionContext.getSessionCacheSize();
+        if (sessionCacheSize > 0) {
+          sslSessionContext.setSessionCacheSize(0);
+        }
         TRUSTED_FACTORY = context.getSocketFactory();
       } catch (GeneralSecurityException e) {
         IOException ioException = new IOException(

--- a/app/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
+++ b/app/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
@@ -89,7 +89,6 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import javax.net.ssl.SSLSessionContext;
 
-
 /**
  * A fluid interface for making HTTP requests using an underlying
  * {@link HttpURLConnection} (or sub-class).
@@ -268,7 +267,7 @@ public class HttpRequest {
     else
       return CHARSET_UTF8;
   }
-  
+
   private static SSLSocketFactory getTrustedFactory()
       throws HttpRequestException {
     if (TRUSTED_FACTORY == null) {

--- a/app/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
+++ b/app/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
@@ -80,7 +80,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.GZIPInputStream;
 
-import javax.net.ssl.*;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.SSLSessionContext;
+
 
 /**
  * A fluid interface for making HTTP requests using an underlying


### PR DESCRIPTION
This improves the energy efficiency of btcontract by applying the Cache Energy Pattern for mobile applications.

The energy pattern was applied in HttpRequest.java . The general idea is to avoid performing unnecessary operations by increasing the size of the cache used. In particular, when a SSLContext is created, if the size of the cache has a limit, it's set to have no limit.